### PR TITLE
Add redundant Class Name test

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ const isolateSink =
     sink.map(
       vtree => {
         if (vtree.sel.indexOf(`cycle-scope-${scope}`) === -1) {
-          const c = `${vtree.sel}.cycle-scope-${scope}`.trim()
+          const c = `${vtree.sel}.cycle-scope-${scope}`
           vtree.sel = c
         }
         return vtree

--- a/src/index.js
+++ b/src/index.js
@@ -152,23 +152,20 @@ const makeDOMDriver =
       view$ => {
         validateDOMDriverInput(view$)
 
-        const rootElem$ = most.create(
-          (add, end, error) => {
-            view$
-              .map(parseTree)
-              .switch()
-              .reduce(
-                (prevView, newView) => {
-                  const vnode = patch(prevView, newView)
-                  add(vnode.elm)
-                  return vnode
-                },
-                rootElem
-              )
-              .then(end)
-              .catch(error)
-          }
-        )
+        const rootElem$ =
+          most.create(
+            add =>
+              view$
+                .flatMap(parseTree)
+                .reduce(
+                  (prevView, newView) => {
+                    patch(prevView, newView)
+                    add(newView.elm)
+                    return newView
+                  }
+                  , rootElem
+                )
+          )
         rootElem$.drain()
 
         return {


### PR DESCRIPTION
After seeing the issue for Cycle-DOM that multiples of the same className was being added, I figured it was highly likely that the same bug would exist here. After adding the test it was readily apparent that the issue did in fact occur.

After adding the `if` statement to ensure that would not happen, I was running into an assertion error involving the className and at first I thought it was some kind of snabbdom patch error so I cleaned up the `rootElem$` to make sure that it was the patched DOM node getting checked.

When that did not fix it, I realized that `h(sel, data, children)` expects `sel` to be a string without spaces to add id's and className's, we were using `vtree.sel` impoperly by using a space.