### PR TITLE
fix(node): Fix importing on node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,12 @@ const {
   style, sub, sup, table, tbody, td, textarea, tfoot, th,
   thead, title, tr, u, ul, video,
 } = require(`hyperscript-helpers`)(h)
-import matchesSelector from 'matches-selector'
+let matchesSelector
+try {
+  matchesSelector = require(`matches-selector`)
+} catch (e) {
+  matchesSelector = () => {}
+}
 import fastMap from 'fast.js/array/map'
 import reduce from 'fast.js/array/reduce'
 import filter from 'fast.js/array/filter'


### PR DESCRIPTION
Add a try catch to avoid matches-selector throwing an erorr
to enable reuse of h() and other functions when running Motorcycle
in the Node.js environment.

Closes #21