### PR TITLE
Update *core* to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "snabbdom-selector": "0.3.2"
   },
   "devDependencies": {
-    "@motorcycle/core": "0.1.7",
+    "@motorcycle/core": "0.2.0",
     "assert": "1.3.0",
     "babel-cli": "6.3.15",
     "babel-core": "6.3.15",

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -432,13 +432,13 @@ describe(`Rendering`, () => {
         DOM: makeDomDriver(createRenderTarget('tab1')),
       })
 
-      sources.DOM.select(':root').observable.skip(4).take(1)
+      sources.DOM.select(':root').observable
         .observe(root => {
           const child = root.children[0]
           assert.notStrictEqual(child, null)
           assert.notStrictEqual(typeof child, 'undefined')
           assert.strictEqual(child.tagName, 'SPAN')
-          assert.strictEqual(child.className, 'tab1 cycle-scope-1')
+          assert.strictEqual(child.className, 'tab2 cycle-scope-2')
           done()
         })
     })


### PR DESCRIPTION
Update @motorcycle/core dev dependency to 0.2.0

Update test which fails due to proper usage of *most*. Updates to *core*
which use `most-subject` have introduced a way to *end* a stream, allowing for
the `.map().switch()`es that occur [here](https://github.com/motorcyclejs/dom/blob/develop/src/vTreeParser.js#L20) and [here](https://github.com/motorcyclejs/dom/blob/develop/src/makeDomDriver.js#L60-L61) to operate properly. The `switch()`es 
terminate inner streams now which was previously impossible. 
This test previously checked a value in the middle of a Stream, 
but now that the `switch()`es can operate as intended, only the last
value of the Stream is received. Update the test to operate on the 
last value expected to be received.

References motorcyclejs/motorcycle#19