### PR TITLE
Render when there are no observers

### DIFF
--- a/src/makeDOMDriver.js
+++ b/src/makeDOMDriver.js
@@ -66,6 +66,8 @@ const makeDOMDriver =
             )
             .skip(1)
 
+        rootVNode$.drain()
+
         return {
           namespace: [],
           select: makeSelectorParser(hold(rootVNode$)),

--- a/src/makeDOMDriver.js
+++ b/src/makeDOMDriver.js
@@ -55,7 +55,7 @@ const makeDOMDriver =
       view$ => {
         domDriverInputGuard(view$)
 
-        const rootVNode$ =
+        const rootVNode$ = hold(
           view$
             .map(vTreeParser)
             .switch()
@@ -65,12 +65,13 @@ const makeDOMDriver =
               rootElement
             )
             .skip(1)
+          )
 
         rootVNode$.drain()
 
         return {
           namespace: [],
-          select: makeSelectorParser(hold(rootVNode$)),
+          select: makeSelectorParser(rootVNode$),
           isolateSink,
           isolateSource,
         }

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -172,6 +172,25 @@ describe(`Rendering`, () => {
         })
     })
 
+  it(`should render when sources are not subscribed to`, done => {
+    const app = () => ({
+      DOM: most.just(div('.test-div', [
+        h2('hello')
+      ]))
+    })
+
+    run(app, {DOM: makeDOMDriver(createRenderTarget())})
+
+    setTimeout(() => {
+      const div_ = document.querySelector('.test-div')
+      assert.strictEqual(div_.tagName, 'DIV')
+      const child = div_.children[0]
+      assert.strictEqual(child.tagName, 'H2')
+      assert.strictEqual(child.textContent, 'hello')
+      done()
+    }, 10)
+  })
+
   it(`should have isolateSource() and isolateSink() in source`, done => {
     function app() {
       return {


### PR DESCRIPTION
Adds fix and test to ensure the view is still being rendered to when there is no observers. i.e. `DOM.select()`

Closes #55 