### PR TITLE
Return empty stream when fromEvent is passed an empty array

### DIFF
--- a/src/fromEvent.js
+++ b/src/fromEvent.js
@@ -1,4 +1,5 @@
 import Stream from 'most/lib/Stream'
+import {empty} from 'most'
 import MulticastSource from 'most/lib/source/MulticastSource'
 import forEach from 'fast.js/array/forEach'
 
@@ -75,8 +76,8 @@ EventTargetSource.prototype.run = function run(sink, scheduler) {
 
 const fromEvent =
   (type, nodes, useCapture = false) => {
-    if (!nodes.length) {
-      throw new Error(`nodes must be a NodeList or an Array of DOM Nodes`)
+    if (!nodes.length || nodes.length === 0) {
+      return empty()
     }
 
     let source

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -658,13 +658,8 @@ describe(`fromEvent`, () => {
     click(nodes[0])
   })
 
-  it(`should throw error if not given a NodeList`, done => {
-    const element = createRenderTargetWithChildren()
-    const nodes = element.querySelector('h1')
-    assert.throws(
-      () => fromEvent('click', nodes, false),
-      /nodes must be a NodeList or an Array of DOM Nodes/
-    )
+  it(`should not throw error if given an empty array`, done => {
+    assert.doesNotThrow(() => fromEvent('click', [], false))
     done()
   })
 })


### PR DESCRIPTION
Return most.empty() when an empty array is passed to fromEvent.
This happens when DOM.select() finds no matching selectors. Previously this would throw an error.
Returning an empty() stream will allow for you application to continue working as expected.

Closes #59 