### PR TITLE
Change to an options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ More examples can be found [here](https://github.com/motorcyclejs/examples).
 
 **container** :: Element|CSS-Selector - A DOM node or a CSS-Selector which points to an existing DOM node that will be used as the initial place to patch the DOM.
 
-**modules** :: Array - An array of [Snabbdom modules](https://github.com/paldepind/snabbdom#creating-modules) which will be used by Snabbdom to add/remove behaviors that are available to you from the `h()` or `hyperscript-helpers` functions.
+**options** :: Object - An (optional) options object.
+
+*optional parameters*
+
+(modules) :: Array - An array of [Snabbdom modules](https://github.com/paldepind/snabbdom#creating-modules) which will be used by Snabbdom to add/remove behaviors that are available to you from the `h()` or `hyperscript-helpers` functions.
 
 ```js
 import {makeDOMDriver} from '@motorcycle/dom'
@@ -55,12 +59,14 @@ makeDOMDriver(document.querySelector('#app'))
 
 /* with modules */
 /* these are the default modules used */
-makeDOMDriver('#app', [
-  require(`snabbdom/modules/class`),
-  require(`snabbdom/modules/props`),
-  require(`snabbdom/modules/attributes`),
-  require(`snabbdom/modules/style`),
-])
+makeDOMDriver('#app', {
+  modules: [
+    require(`snabbdom/modules/class`),
+    require(`snabbdom/modules/props`),
+    require(`snabbdom/modules/attributes`),
+    require(`snabbdom/modules/style`),
+  ]
+})
 ```
 
 ### h(selector, data, children)

--- a/src/makeDOMDriver.js
+++ b/src/makeDOMDriver.js
@@ -54,6 +54,10 @@ const makeDOMDriver =
   (containerElementSelectors,
     {modules = defaultOptions.modules} = defaultOptions
   ) => {
+    if (!Array.isArray(modules)) {
+      throw new Error(`Optional modules option must be ` +
+        `an array for snabbdom modules`)
+    }
     const patch = snabbdom.init(modules)
     const rootElement = domSelectorParser(containerElementSelectors)
 

--- a/src/makeDOMDriver.js
+++ b/src/makeDOMDriver.js
@@ -41,13 +41,19 @@ const domDriverInputGuard =
     }
   }
 
-const makeDOMDriver =
-  (containerElementSelectors, modules = [
+const defaultOptions = {
+  modules: [
     require(`snabbdom/modules/class`),
     require(`snabbdom/modules/props`),
     require(`snabbdom/modules/attributes`),
     require(`snabbdom/modules/style`),
-  ]) => {
+  ],
+}
+
+const makeDOMDriver =
+  (containerElementSelectors,
+    {modules = defaultOptions.modules} = defaultOptions
+  ) => {
     const patch = snabbdom.init(modules)
     const rootElement = domSelectorParser(containerElementSelectors)
 

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -67,6 +67,7 @@ describe(`Rendering`, () => {
       assert.throws(() => {
         makeDOMDriver(createRenderTarget(), {modules: `1`})
       }, /Optional modules option must be an array for snabbdom modules/)
+      done()
     })
   })
 

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -53,6 +53,21 @@ describe(`Rendering`, () => {
       }, /Given container is not a DOM element neither a selector string\./)
       done()
     })
+
+    it(`should accept an options object with key modules`, done => {
+      assert.doesNotThrow(() => {
+        makeDOMDriver(createRenderTarget(), {modules: [
+          require('snabbdom/modules/props')
+        ]})
+      })
+      done()
+    })
+
+    it(`should throw an error if modules are not an array`, done => {
+      assert.throws(() => {
+        makeDOMDriver(createRenderTarget(), {modules: `1`})
+      }, /Optional modules option must be an array for snabbdom modules/)
+    })
   })
 
   describe(`DOM Driver`, () => {


### PR DESCRIPTION
Changes the second parameter to `makeDOMDriver()` to be an options object instead of an array of snabbdom modules.

Closes #57 