### PR TITLE
Event delegation - Options Object - Render with no observers - Static VTree option

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "@most/hold": "0.2.0",
     "fast.js": "0.1.1",
     "hyperscript-helpers": "2.0.2",
-    "snabbdom": "0.2.8",
-    "snabbdom-selector": "0.3.2"
+    "matches-selector": "1.0.0",
+    "snabbdom": "0.2.8"
   },
   "devDependencies": {
     "@motorcycle/core": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "fast.js": "0.1.1",
     "hyperscript-helpers": "2.0.2",
     "matches-selector": "1.0.0",
-    "snabbdom": "0.2.8"
+    "snabbdom": "0.2.8",
+    "snabbdom-selector": "0.3.2"
   },
   "devDependencies": {
     "@motorcycle/core": "0.2.0",

--- a/src/events.js
+++ b/src/events.js
@@ -1,22 +1,43 @@
 import {empty} from 'most'
 import fromEvent from './fromEvent'
+import {makeIsStrictlyInRootScope} from './select'
 
-const makeEventsSelector =
-  element$ =>
-    (type, useCapture = false) => {
-      if (typeof type !== `string`) {
-        throw new Error(`DOM drivers events() expects argument to be a ` +
-          `string representing the event type to listen for.`)
-      }
-      return element$
-        .map(
-          elements =>
-            elements ?
-              fromEvent(type, elements, useCapture) :
-              empty()
-        )
-        .switch()
-        .multicast()
+let matchesSelector
+try {
+  matchesSelector = require(`matches-selector`)
+} catch (err) {
+  matchesSelector = () => {}
+}
+
+function makeEventsSelector(element$, selector) {
+  return function eventsSelector(type, useCapture = false) {
+    if (typeof type !== `string`) {
+      throw new Error(`DOM drivers events() expects argument to be a ` +
+        `string representing the event type to listen for.`)
     }
+    return element$
+      .map(elements => {
+        if (!elements) {
+          return empty()
+        }
 
-export {makeEventsSelector}
+        if (matchesSelector(elements, selector.join(` `))) {
+          return fromEvent(type, elements, useCapture)
+        }
+
+        return fromEvent(type, elements, useCapture)
+          .filter(ev => {
+            if (matchesSelector(ev.srcElement, selector.join(` `)) ||
+              matchesSelector(ev.srcElement, selector.join(``)))
+            {
+              return makeIsStrictlyInRootScope(selector)(ev.srcElement)
+            }
+            return false
+          })
+      })
+      .switch()
+      .multicast()
+  }
+}
+
+export default makeEventsSelector

--- a/src/events.js
+++ b/src/events.js
@@ -34,10 +34,10 @@ function makeEventsSelector(element$, selector) {
 
         return fromEvent(type, elements, useCapture)
           .filter(ev => {
-            if (matchesSelector(ev.srcElement, selector.join(` `)) ||
-              matchesSelector(ev.srcElement, selector.join(``)))
+            if (matchesSelector(ev.target, selector.join(` `)) ||
+              matchesSelector(ev.target, selector.join(``)))
             {
-              return makeIsStrictlyInRootScope(selector)(ev.srcElement)
+              return makeIsStrictlyInRootScope(selector)(ev.target)
             }
             return false
           })

--- a/src/events.js
+++ b/src/events.js
@@ -16,6 +16,13 @@ function makeEventsSelector(element$, selector) {
         `string representing the event type to listen for.`)
     }
     return element$
+      .map(element => {
+        return {element, selector}
+      })
+      .skipRepeatsWith((prev, curr) => {
+        return prev.selector.join(``) === curr.selector.join(``)
+      })
+      .map(({element}) => element)
       .map(elements => {
         if (!elements) {
           return empty()

--- a/src/fromEvent.js
+++ b/src/fromEvent.js
@@ -1,6 +1,5 @@
 import Stream from 'most/lib/Stream'
 import MulticastSource from 'most/lib/source/MulticastSource'
-import forEach from 'fast.js/array/forEach'
 
 const tryEvent =
   (time, event, sink) => {
@@ -41,16 +40,10 @@ EventAdapter.prototype.dispose = function dispose() {
 
 const initEventTarget =
   (nodes, type, listener, useCapture) => { // eslint-disable-line
-    forEach(
-      nodes,
-      kValue => kValue.addEventListener(type, listener, useCapture)
-    )
+    nodes.addEventListener(type, listener, useCapture)
 
     const dispose = (type_, target) => {
-      forEach(
-        target,
-        kValue => kValue.removeEventListener(type_, listener, useCapture)
-      )
+      target.removeEventListener(type_, listener, useCapture)
     }
 
     return dispose
@@ -75,12 +68,8 @@ EventTargetSource.prototype.run = function run(sink, scheduler) {
 
 const fromEvent =
   (type, nodes, useCapture = false) => {
-    if (!nodes.length) {
-      throw new Error(`nodes must be a NodeList or an Array of DOM Nodes`)
-    }
-
     let source
-    if (nodes[0].addEventListener && nodes[0].removeEventListener) {
+    if (nodes.addEventListener && nodes.removeEventListener) {
       source = new MulticastSource(
         new EventTargetSource(type, nodes, useCapture)
       )

--- a/src/isolate.js
+++ b/src/isolate.js
@@ -13,6 +13,6 @@ const isolateSink =
         }
         return vTree
       }
-    )
+    ).multicast()
 
 export {isolateSink, isolateSource}

--- a/src/makeDOMDriver.js
+++ b/src/makeDOMDriver.js
@@ -1,4 +1,3 @@
-import {create} from 'most'
 import hold from '@most/hold'
 import snabbdom from 'snabbdom'
 import h from 'snabbdom/h'

--- a/src/makeDOMDriver.js
+++ b/src/makeDOMDriver.js
@@ -1,3 +1,4 @@
+import {create} from 'most'
 import hold from '@most/hold'
 import snabbdom from 'snabbdom'
 import h from 'snabbdom/h'
@@ -7,30 +8,32 @@ import selectorParser from 'snabbdom-selector/lib/selectorParser'
 import {domSelectorParser} from './utils'
 import vTreeParser from './vTreeParser'
 import {isolateSink, isolateSource} from './isolate'
-import {makeSelectorParser} from './select'
+import makeElementSelector from './select'
 
-function vNodeWrapper(vNode, rootElement) {
-  const {tagName: selectorTagName, id: selectorId} = selectorParser(vNode.sel)
-  const vNodeClassName = classNameFromVNode(vNode)
-  const {data: vNodeData = {}} = vNode
-  const {props: vNodeDataProps = {}} = vNodeData
-  const {id: vNodeId = selectorId} = vNodeDataProps
+function makeVNodeWrapper(rootElement) {
+  return function vNodeWrapper(vNode) {
+    const {tagName: selectorTagName, id: selectorId} = selectorParser(vNode.sel)
+    const vNodeClassName = classNameFromVNode(vNode)
+    const {data: vNodeData = {}} = vNode
+    const {props: vNodeDataProps = {}} = vNodeData
+    const {id: vNodeId = selectorId} = vNodeDataProps
 
-  const isVNodeAndRootElementIdentical =
-    vNodeId === rootElement.id &&
-    selectorTagName === rootElement.tagName &&
-    vNodeClassName === rootElement.className
+    const isVNodeAndRootElementIdentical =
+      vNodeId === rootElement.id &&
+      selectorTagName === rootElement.tagName &&
+      vNodeClassName === rootElement.className
 
-  if (isVNodeAndRootElementIdentical) {
-    return vNode
+    if (isVNodeAndRootElementIdentical) {
+      return vNode
+    }
+
+    const {tagName, id, className} = rootElement
+    const elementId = id ? `#${id}` : ``
+    const elementClassName = className ?
+      `.${className.split(` `).join(`.`)}` :
+      ``
+    return h(`${tagName}${elementId}${elementClassName}`, {}, [vNode])
   }
-
-  const {tagName, id, className} = rootElement
-  const elementId = id ? `#${id}` : ``
-  const elementClassName = className ?
-    `.${className.split(` `).join(`.`)}` :
-    ``
-  return h(`${tagName}${elementId}${elementClassName}`, {}, [vNode])
 }
 
 const domDriverInputGuard =
@@ -55,20 +58,23 @@ const makeDOMDriver =
       view$ => {
         domDriverInputGuard(view$)
 
-        const rootVNode$ =
+        const rootElement$ = hold(create(add => {
           view$
             .map(vTreeParser)
             .switch()
-            .scan(
-              (prevVNode, vNode) =>
-                patch(prevVNode, vNodeWrapper(vNode, rootElement)),
-              rootElement
-            )
-            .skip(1)
+            .map(makeVNodeWrapper(rootElement))
+            .reduce((prev, curr) => {
+              const vNode = patch(prev, curr)
+              add(vNode.elm)
+              return vNode
+            }, rootElement)
+        }))
+
+        rootElement$.drain()
 
         return {
           namespace: [],
-          select: makeSelectorParser(hold(rootVNode$)),
+          select: makeElementSelector(rootElement$),
           isolateSink,
           isolateSource,
         }

--- a/src/makeDOMDriver.js
+++ b/src/makeDOMDriver.js
@@ -63,6 +63,10 @@ const makeDOMDriver =
     const DomDriver =
       view$ => {
         domDriverInputGuard(view$)
+        if (!Array.isArray(modules)) {
+          throw new Error(`Optional modules option must be ` +
+          `an array for snabbdom modules`)
+        }
 
         const rootElement$ = hold(
           view$

--- a/src/select.js
+++ b/src/select.js
@@ -1,104 +1,63 @@
-import reduce from 'fast.js/array/reduce'
-import concat from 'fast.js/array/concat'
-import filter from 'fast.js/array/filter'
-import map from 'fast.js/array/map'
-
-import matchesSelector from 'snabbdom-selector'
-import classNameFromVNode from 'snabbdom-selector/lib/classNameFromVNode'
-
-import {SCOPE_PREFIX} from './utils'
+import makeEventsSelector from './events'
 import {isolateSink, isolateSource} from './isolate'
-import {makeEventsSelector} from './events'
 
-const makeIsVNodeStrictlyInRootScope =
-  namespace => leaf => {
-    const isClassForeign =
-      className =>
-        className.indexOf(SCOPE_PREFIX) > -1 &&
-        namespace.indexOf(`.${className}`) === -1
+import {filter, concat} from 'fast.js/array'
 
-    const isClassDomestic =
-      className =>
-        className.indexOf(SCOPE_PREFIX) > -1 &&
-        namespace.indexOf(`.${className}`) > -1
-
-    let vNode = leaf
-    for (; vNode; vNode = vNode.parent) {
-      const classNames = classNameFromVNode(vNode).split(` `)
-      if (classNames.some(isClassDomestic)) {
+function makeIsStrictlyInRootScope(namespace) {
+  const classIsForeign = c => {
+    const matched = c.match(/cycle-scope-(\S+)/)
+    return matched && namespace.indexOf(`.${c}`) === -1
+  }
+  const classIsDomestic = c => {
+    const matched = c.match(/cycle-scope-(\S+)/)
+    return matched && namespace.indexOf(`.${c}`) !== -1
+  }
+  return function isStrictlyInRootScope(leaf) {
+    for (let el = leaf; el !== null; el = el.parentElement) {
+      const split = String.prototype.split
+      const classList = el.classList || split.call(el.className, ` `)
+      if (Array.prototype.some.call(classList, classIsDomestic)) {
         return true
       }
-      if (classNames.some(isClassForeign)) {
+      if (Array.prototype.some.call(classList, classIsForeign)) {
         return false
       }
     }
     return true
   }
-
-const elementFromVNode =
-  vNode =>
-    vNode.data && vNode.data.vnode ?
-      vNode.data.vnode.elm :
-      vNode.elm
-
-const mapVNodeToElement =
-  vNode =>
-    Array.isArray(vNode) ?
-      map(vNode, elementFromVNode) :
-      elementFromVNode(vNode)
-
-function makeVNodesSelectorFilter(selectors, namespace) {
-  return vNode => {
-    const matches = Array.isArray(vNode) ?
-      reduce(vNode, (accumulator, kValue) =>
-        concat(matchesSelector(selectors, kValue), accumulator),
-      []) :
-      matchesSelector(selectors, vNode)
-    return filter(matches, makeIsVNodeStrictlyInRootScope(namespace))
-  }
 }
 
-const sameElements =
-  (prevElements, elements) => {
-    if (prevElements.length !== elements.length) {
-      return false
-    }
-    return prevElements.every(
-      (element, index) => element === elements[index]
-    )
-  }
-
-function makeSelectorParser(vNode$) {
-  // We use a regular `function` instead of a lambda function
-  // because we need to have access to `this.namespace`.
-  return function selectorParser_(selectors) {
-    if (typeof selectors !== `string`) {
+function makeElementSelector(rootElem$) {
+  return function DOMSelect(selector) {
+    if (typeof selector !== `string`) {
       throw new Error(`DOM drivers select() expects first argument to be a ` +
-        `string containing one or more CSS selectors.`)
+        `string as a CSS selector`)
     }
     const namespace = this.namespace
-    const scopedSelectors = `${namespace.join(` `)} ${selectors}`.trim()
-    const filteredVNode$ =
-      selectors.trim() === `:root` ?
-        vNode$ :
-        vNode$.map(
-          makeVNodesSelectorFilter(
-            scopedSelectors, namespace.concat(selectors)
-          )
-        )
+    const scopedSelector = concat(
+      namespace,
+      selector.trim() === `:root` ? `` : selector.trim()
+    )
     return {
-      observable: filteredVNode$.map(mapVNodeToElement),
-      namespace: namespace.concat(selectors),
-      select: makeSelectorParser(filteredVNode$),
-      events: makeEventsSelector(
-        filteredVNode$
-        .map(mapVNodeToElement)
-        .skipRepeatsWith(sameElements)
-      ),
+      observable: rootElem$.map(rootEl => {
+        if (scopedSelector.join(``) === ``) {
+          return rootEl
+        }
+        let nodeList = rootEl.querySelectorAll(scopedSelector.join(` `).trim())
+        if (nodeList.length === 0) {
+          nodeList = rootEl.querySelectorAll(scopedSelector.join(``))
+        }
+        const array = Array.prototype.slice.call(nodeList)
+        return filter(array, makeIsStrictlyInRootScope(scopedSelector))
+      }),
+      namespace: namespace.concat(selector),
+      select: makeElementSelector(rootElem$),
+      events: makeEventsSelector(rootElem$, scopedSelector),
       isolateSource,
       isolateSink,
     }
   }
 }
 
-export {makeSelectorParser, sameElements}
+export default makeElementSelector
+export {makeIsStrictlyInRootScope}

--- a/src/vTreeParser.js
+++ b/src/vTreeParser.js
@@ -14,7 +14,9 @@ const combineVTreeStreams =
 
 const vTreeParser =
   vTree => {
-    if (!vTree) {
+    if (vTree.data && vTree.data.static) {
+      return most.just(vTree)
+    } else if (!vTree) {
       return null
     } else if (vTree.observe) {
       return vTree.map(vTreeParser).switch()

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -52,6 +52,22 @@ describe(`Rendering`, () => {
       }, /Given container is not a DOM element neither a selector string\./)
       done()
     })
+
+    it(`should accept an options object with key modules`, done => {
+      assert.doesNotThrow(() => {
+        makeDOMDriver(createRenderTarget(), {modules: [
+          require('snabbdom/modules/props')
+        ]})
+      })
+      done()
+    })
+
+    it(`should throw an error if modules are not an array`, done => {
+      assert.throws(() => {
+        makeDOMDriver(createRenderTarget(), {modules: `1`})(most.just(div()))
+      }, /Optional modules option must be an array for snabbdom modules/)
+      done()
+    })
   })
 
   describe(`DOM Driver`, () => {

--- a/test/browser/perf/index.js
+++ b/test/browser/perf/index.js
@@ -1,5 +1,5 @@
 import {run} from '@motorcycle/core'
-import {makeDomDriver, h} from '../../../src'
+import {makeDOMDriver, h} from '../../../src'
 import most from 'most'
 import {combineArray} from 'most/lib/combinator/combine'
 import map from 'fast.js/array/map'
@@ -72,7 +72,7 @@ function main(sources) {
   }
 }
 
-run(main, {dom: makeDomDriver(`#test-container`, [
+run(main, {dom: makeDOMDriver(`#test-container`, [
   require('snabbdom/modules/props'),
   require('snabbdom/modules/style')
 ])});

--- a/test/browser/perf/index.js
+++ b/test/browser/perf/index.js
@@ -6,7 +6,7 @@ import map from 'fast.js/array/map'
 
 function InputCount(dom, initialValue) {
   const id = `.component-count`
-  const value$ = dom.select(id)
+  const value$ = dom.select(id, true)
       .events(`input`)
       .map(ev => ev.target.value)
       .startWith(initialValue)
@@ -51,7 +51,7 @@ function CycleJSLogo(id) {
 }
 
 function view(value, inputCountVTree, componentDOMs) {
-  return h('div', [
+  return h('div', {static: true}, [
     h('h2', [`# of Components: ${value}`]),
     inputCountVTree,
     h('div', componentDOMs)

--- a/test/browser/perf/index.js
+++ b/test/browser/perf/index.js
@@ -72,7 +72,7 @@ function main(sources) {
   }
 }
 
-run(main, {dom: makeDOMDriver(`#test-container`, [
+run(main, {dom: makeDOMDriver(`#test-container`, {modules: [
   require('snabbdom/modules/props'),
   require('snabbdom/modules/style')
-])});
+]})});


### PR DESCRIPTION
I totally know this is frowned upon, but this closes 3 issues. Moving to event delegation was a very large undertaking, and renders the other PR's next to impossible to merge easliy.

So,

1. Event Delegation - Moves from snabbdom-selector and matching against the VTree to attaching event listeners to the root Element and filtering for the proper targets. See cyclejs/cycle-dom#85 for more discussion.

2. Options Object - Supersedes #61 

3. Render with no observers - Supersedes #56 

4. Static VTree option - Solution for #58 

Closes #55
Closes #57
Closes #58
Closes #59 - Renders this unneeded.

References #4