### PR TITLE
Fix select() sematics

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -11,13 +11,14 @@ function makeIsStrictlyInRootScope(namespace) {
     return matched && namespace.indexOf(`.${c}`) !== -1
   }
   return function isStrictlyInRootScope(leaf) {
+    const some = Array.prototype.some
+    const split = String.prototype.split
     for (let el = leaf; el; el = el.parentElement) {
-      const split = String.prototype.split
       const classList = el.classList || split.call(el.className, ` `)
-      if (Array.prototype.some.call(classList, classIsDomestic)) {
+      if (some.call(classList, classIsDomestic)) {
         return true
       }
-      if (Array.prototype.some.call(classList, classIsForeign)) {
+      if (some.call(classList, classIsForeign)) {
         return false
       }
     }
@@ -26,16 +27,56 @@ function makeIsStrictlyInRootScope(namespace) {
 }
 
 const isValidString = param => typeof param === `string` && param.length > 0
-const startsWith = (string, start) => string[0] === start
+
+const contains = (str, match) => str.indexOf(match) > -1
+
 const isNotTagName = param =>
-    isValidString(param) && startsWith(param, `.`) || startsWith(param, `#`) ||
-    startsWith(param, `:`) || startsWith(param, `*`)
+    isValidString(param) && contains(param, `.`) ||
+    contains(param, `#`) || contains(param, `:`)
 
 function sortNamespace(a, b) {
   if (isNotTagName(a) && isNotTagName(b)) {
     return 0
   }
   return isNotTagName(a) ? 1 : -1
+}
+
+function removeDuplicates(arr) {
+  const newArray = []
+  arr.forEach((element) => {
+    if (newArray.indexOf(element) === -1) {
+      newArray.push(element)
+    }
+  })
+  return newArray
+}
+
+const getScope = namespace =>
+  namespace.filter(c => c.indexOf(`.cycle-scope`) > -1)
+
+function makeFindElements(namespace) {
+  return function findElements(rootElement) {
+    if (namespace.join(``) === ``) {
+      return rootElement
+    }
+    const slice = Array.prototype.slice
+
+    const scope = getScope(namespace)
+    // Uses global selector && is isolated
+    if (namespace.indexOf(`*`) > -1 && scope.length > 0) {
+      // grab top-level boundary of scope
+      const topNode = rootElement.querySelector(scope.join(` `))
+      // grab all children
+      const childNodes = topNode.getElementsByTagName(`*`)
+      return removeDuplicates([topNode].concat(slice.call(childNodes)))
+        .filter(makeIsStrictlyInRootScope(namespace))
+    }
+
+    return removeDuplicates(
+        slice.call(rootElement.querySelectorAll(namespace.join(` `)))
+        .concat(slice.call(rootElement.querySelectorAll(namespace.join(``))))
+      ).filter(makeIsStrictlyInRootScope(namespace))
+  }
 }
 
 function makeElementSelector(rootElement$) {
@@ -50,19 +91,9 @@ function makeElementSelector(rootElement$) {
     const childNamespace = trimmedSelector === `:root` ?
       namespace :
       namespace.concat(trimmedSelector).sort(sortNamespace)
-    const element$ = rootElement$.map(rootEl => {
-      if (childNamespace.join(``) === ``) {
-        return rootEl
-      }
-      let nodeList = rootEl.querySelectorAll(childNamespace.join(` `))
-      if (nodeList.length === 0) {
-        nodeList = rootEl.querySelectorAll(childNamespace.join(``))
-      }
-      const array = Array.prototype.slice.call(nodeList)
-      return array.filter(makeIsStrictlyInRootScope(childNamespace))
-    })
+
     return {
-      observable: element$,
+      observable: rootElement$.map(makeFindElements(childNamespace)),
       namespace: childNamespace,
       select: makeElementSelector(rootElement$),
       events: makeEventsSelector(rootElement$, childNamespace),

--- a/src/select.js
+++ b/src/select.js
@@ -73,9 +73,12 @@ function makeFindElements(namespace) {
     }
 
     return removeDuplicates(
-        slice.call(rootElement.querySelectorAll(namespace.join(` `)))
-        .concat(slice.call(rootElement.querySelectorAll(namespace.join(``))))
-      ).filter(makeIsStrictlyInRootScope(namespace))
+      slice.call(
+        rootElement.querySelectorAll(namespace.join(` `))
+      ).concat(slice.call(
+        rootElement.querySelectorAll(namespace.join(``))
+      ))
+    ).filter(makeIsStrictlyInRootScope(namespace))
   }
 }
 

--- a/test/browser/select.js
+++ b/test/browser/select.js
@@ -156,4 +156,90 @@ describe('DOMSource.select()', function () {
         done();
       });
   });
+
+  it('should allow DOM.select()ing its own root without classname or id', function(done) {
+    function app(sources) {
+      return {
+        DOM: most.just(
+          h3([
+            span([
+              h4('.bar', 'hello')
+            ])
+          ])
+        )
+      };
+    }
+
+    const {sinks, sources, dispose} = run(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    sources.DOM.select('h3').observable.take(1).observe(function (elements) {
+      assert.strictEqual(Array.isArray(elements), true);
+      assert.strictEqual(elements.length, 1);
+      const correctElement = elements[0];
+      assert.notStrictEqual(correctElement, null);
+      assert.notStrictEqual(typeof correctElement, 'undefined');
+      assert.strictEqual(correctElement.tagName, 'H3');
+      dispose();
+      done();
+    });
+  });
+
+  it('should allow DOM.select()ing all elements with `*`', function(done) {
+    function app(sources) {
+      return {
+        DOM: most.just(
+          h3('.top-most', [
+            span([
+              h4('.bar', 'hello')
+            ])
+          ])
+        )
+      };
+    }
+
+    const {sinks, sources, dispose} = run(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+
+     sources.DOM.select('*').observable.take(1).observe(function (elements) {
+      assert.strictEqual(Array.isArray(elements), true);
+      assert.strictEqual(elements.length, 3);
+      dispose();
+      done();
+    });
+  });
+
+ it('should select() isolated element with tag + class', function (done) {
+   function app() {
+     return {
+       DOM: most.just(
+         h3('.top-most', [
+           h2('.bar', 'Wrong'),
+           div([
+             h4('.bar', 'Correct')
+           ])
+         ])
+       )
+     };
+   };
+
+   const {sinks, sources, dispose} = run(app, {
+     DOM: makeDOMDriver(createRenderTarget())
+   });
+
+   // Make assertions
+   sources.DOM.select('h4.bar').observable.take(1).observe(elements => {
+     assert.strictEqual(elements.length, 1);
+     const correctElement = elements[0];
+     assert.notStrictEqual(correctElement, null);
+     assert.notStrictEqual(typeof correctElement, 'undefined');
+     assert.strictEqual(correctElement.tagName, 'H4');
+     assert.strictEqual(correctElement.textContent, 'Correct');
+     dispose();
+     done();
+   });
+ });
 });


### PR DESCRIPTION
Fixes using a tagName at the root of isolation, a tagName + className at the root of
isolation and the use of '*' in and out of isolation.

Closes #80