### PR TITLE
Use classes module for selectors

### DIFF
--- a/src/hyperscript/hyperscript.ts
+++ b/src/hyperscript/hyperscript.ts
@@ -54,6 +54,19 @@ export const h: HyperscriptFn = <HyperscriptFn>function (selector: string, b?: a
     }
   }
 
+  const classNames = findClassNames(selector);
+
+  if (classNames) {
+    selector = selector.replace('.' + classNames, '');
+
+    const classes: any = data.class || {};
+    classNames.split('.').forEach((className: string) => {
+      classes[className] = true;
+    })
+
+    data.class = classes;
+  }
+
   if (Array.isArray(children)) {
     children = children.filter(Boolean)
     for (i = 0; i < children.length; ++i) {
@@ -90,4 +103,14 @@ export class MotorcycleVNode implements VNode {
   static createTextVNode(text: string): MotorcycleVNode {
     return new MotorcycleVNode(undefined, undefined, undefined, text, undefined, undefined)
   }
+}
+
+function findClassNames(selector: string) {
+  const hashIndex = selector.indexOf('#');
+  const dotIndex = selector.indexOf('.', hashIndex);
+  const firstClassNamePosition = dotIndex > 0 ? dotIndex : selector.length;
+
+  if (!dotIndex) return null
+
+  return selector.slice(firstClassNamePosition + 1);
 }

--- a/src/makeDOMDriver.ts
+++ b/src/makeDOMDriver.ts
@@ -7,7 +7,7 @@ import { DOMSource } from './DOMSource';
 import { MainDOMSource } from './MainDOMSource'
 import { VNodeWrapper } from './VNodeWrapper'
 import { getElement } from './util'
-import defaultModules from './modules';
+import defaultModules, { ClassModule } from './modules';
 import { IsolateModule } from './modules/isolate'
 import { transposeVNode } from './transposition'
 import { EventDelegator } from './EventDelegator'
@@ -26,7 +26,7 @@ export function makeDOMDriver(container: string | HTMLElement, options?: DOMDriv
   const transposition = options.transposition || false;
   const modules = options.modules || defaultModules;
   const isolateModule = new IsolateModule((new Map<string, HTMLElement>()));
-  const patch = init([isolateModule.createModule()].concat(modules));
+  const patch = init([isolateModule.createModule(), ClassModule].concat(modules));
   const rootElement = getElement(container);
   const vnodeWrapper = new VNodeWrapper(rootElement);
   const delegators = new Map<string, EventDelegator>();

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -9,7 +9,7 @@ const StyleModule = require('snabbdom/modules/style')
 const HeroModule = require('snabbdom/modules/hero')
 const DataSetModule = require('snabbdom/modules/dataset')
 
-export default [StyleModule, ClassModule, PropsModule, AttrsModule]
+export default [StyleModule, PropsModule, AttrsModule]
 
 export {
   StyleModule, ClassModule,

--- a/test/browser/events.ts
+++ b/test/browser/events.ts
@@ -389,7 +389,7 @@ describe('DOMSource.events()', function () {
     sources.DOM.select('.form').events('reset').observe((ev: Event) => {
       assert.strictEqual(ev.type, 'reset');
       assert.strictEqual((ev.target as HTMLElement).tagName, 'FORM');
-      assert.strictEqual((ev.target as HTMLElement).className, 'form');
+      // assert.strictEqual((ev.target as HTMLElement).className, 'form');
       done();
     });
 

--- a/test/browser/events.ts
+++ b/test/browser/events.ts
@@ -389,7 +389,7 @@ describe('DOMSource.events()', function () {
     sources.DOM.select('.form').events('reset').observe((ev: Event) => {
       assert.strictEqual(ev.type, 'reset');
       assert.strictEqual((ev.target as HTMLElement).tagName, 'FORM');
-      // assert.strictEqual((ev.target as HTMLElement).className, 'form');
+      assert.strictEqual((ev.target as HTMLElement).className, 'form');
       done();
     });
 

--- a/test/browser/isolation.ts
+++ b/test/browser/isolation.ts
@@ -86,7 +86,7 @@ describe('isolateSink', function () {
     let dispose: any;
     // Make assertions
     sinks.DOM.take(1).observe(function (vtree: VNode) {
-      assert.strictEqual(vtree.sel, 'h3.top-most');
+      assert.strictEqual(vtree.sel, 'h3');
       assert.strictEqual((vtree.data as any).isolate, '$$MOTORCYCLEDOM$$-foo');
       setTimeout(() => {
         dispose();
@@ -133,7 +133,7 @@ describe('isolateSink', function () {
     let dispose: any;
     // Make assertions
     sinks.DOM.skip(2).take(1).observe(function (vtree: VNode) {
-      assert.strictEqual(vtree.sel, 'span.tab1');
+      assert.strictEqual(vtree.sel, 'span');
       assert.strictEqual((vtree.data as any).isolate, '$$MOTORCYCLEDOM$$-1');
       dispose();
       done();

--- a/test/node/hyperscript.ts
+++ b/test/node/hyperscript.ts
@@ -27,8 +27,8 @@ describe('hyperscript', () => {
       const data = {}
       const vnode = div('.hi', data, 0)
 
-      assert(vnode.sel === 'div.hi')
       assert(vnode.data === data)
+      assert((vnode.data as any).class.hi)
       assert(vnode.text === '0')
     })
   })


### PR DESCRIPTION
Avoids subtle bugs with rerendering of elements
This PR adds the class module to always be used with snabbdom


Breaking Changes:
  BEFORE: h('div.foo') ->  { sel: 'div.foo' ... }
  AFTER: h('div.foo') -> { sel: 'div', data: { class: { foo: true } } }