### PR TITLE
fix(events): fix subtle bug

### DIFF
--- a/src/EventDelegator.ts
+++ b/src/EventDelegator.ts
@@ -8,6 +8,7 @@ let gDestinationId: number = 0
 interface Destination {
   subject: Subject<Event>
   scopeChecker: ScopeChecker
+  topElement: HTMLElement
   selector: string
   destinationId: number
 }
@@ -84,9 +85,11 @@ export class EventDelegator {
       if (!dest.scopeChecker.isStrictlyInRootScope(el)) {
         continue
       }
-      if (matchesSelector(el, dest.selector)) {
+      if (dest.selector && matchesSelector(el, dest.selector)) {
         this.mutateEventCurrentTarget(ev, el)
         dest.subject.next(ev)
+      } else if (!dest.selector && this.isolateModule.isIsolatedElement(dest.topElement)) {
+        dest.subject.next(ev);
       }
     }
   }
@@ -100,11 +103,11 @@ export class EventDelegator {
     }
   }
 
-  addDestination(subject: Subject<Event>, namespace: Array<string>, destinationId: number) {
+  addDestination(subject: Subject<Event>, namespace: Array<string>, destinationId: number, topElement: HTMLElement) {
     const scope = getScope(namespace)
     const selector = getSelectors(namespace)
     const scopeChecker = new ScopeChecker(scope, this.isolateModule)
-    this.destinations.push({subject, scopeChecker, selector, destinationId})
+    this.destinations.push({subject, scopeChecker, selector, topElement, destinationId})
   }
 
   createDestinationId(): number {

--- a/src/MainDOMSource.ts
+++ b/src/MainDOMSource.ts
@@ -191,7 +191,7 @@ export class MainDOMSource implements DOMSource {
               return empty();
             })
 
-        delegator.addDestination(eventSubject, namespace, destinationId)
+        delegator.addDestination(eventSubject, namespace, destinationId, top as HTMLElement);
 
         return stream;
       })


### PR DESCRIPTION
In some very strange obscure edge cases, isolation with a call to DOMSource.events() can
cause a Destination's selector to be an empty string. This will throw an error that
Element.matchesSelector() can not be called with empty string. The fix, when the selector
is an empty string, test if the element is in isolation. If it is, continue to push the
event to its associated event subject.