### PR TITLE
fix(virtual-dom): fix test node patching errors

### DIFF
--- a/src/virtual-dom/htmldomapi.ts
+++ b/src/virtual-dom/htmldomapi.ts
@@ -37,8 +37,8 @@ export function nextSibling(node: Element | Text): Node | Element {
   return node.nextSibling as Node | Element;
 }
 
-export function tagName(node: Element): string {
-  return node.tagName;
+export function tagName(node: Element | Text): string {
+  return (node as Element).tagName || '';
 }
 
 export function setTextContent(node: Element | Text, text: string): void {

--- a/src/virtual-dom/init.ts
+++ b/src/virtual-dom/init.ts
@@ -180,6 +180,7 @@ export function init(
             createElm(newStartVnode, insertedVnodeQueue),
             (oldStartVnode as VNode).elm as Element,
           );
+
           newStartVnode = newCh[++newStartIdx];
         } else {
           elmToMove = oldCh[idxInOld];
@@ -212,6 +213,13 @@ export function init(
       i(oldVnode, vnode);
     }
     let elm = vnode.elm = oldVnode.elm, oldCh = oldVnode.children, ch = vnode.children;
+
+    if (vnode.id)
+      elm.id = vnode.id;
+
+    if (vnode.className)
+      elm.className = vnode.className;
+
     if (oldVnode === vnode) return;
     if (!sameVNode(oldVnode, vnode)) {
       let parentElm = (api as SnabbdomAPI<Element, Text, Node>).parentNode(oldVnode.elm as Element);

--- a/src/virtual-dom/util.ts
+++ b/src/virtual-dom/util.ts
@@ -30,8 +30,8 @@ export function emptyNodeAt(elm: HTMLElement): VNode {
     elm.className,
     elm.id,
     {},
-    elm.children ? Array.prototype.slice.call(elm.children).map(emptyNodeAt) : [],
-    undefined,
+    elm.children ? Array.prototype.slice.call(elm.childNodes).map(emptyNodeAt) : [],
+    elm.textContent || void 0,
     elm,
     undefined,
   );

--- a/test/driver/integration/rendering.ts
+++ b/test/driver/integration/rendering.ts
@@ -1,0 +1,82 @@
+import * as assert from 'assert';
+import { Stream, just } from 'most';
+import { makeDomDriver, div, h2, a, p, DomSource, VNode } from '../../../src';
+import { run } from '@motorcycle/core';
+
+interface DomSources {
+  dom: DomSource;
+}
+
+interface DomSinks {
+  dom: Stream<VNode>;
+}
+
+describe.only('rendering', () => {
+  it('patches text nodes initially present on rootElement', (done) => {
+    function main() {
+      const dom = just(
+        div('#page', {}, [
+          h2('Home'),
+          div({}, [
+            a('.connect', { props: { href: '/connect' } }, 'Connect'),
+            p(' | '),
+            a('.signin', { props: { href: '/signin' } }, 'Sign In'),
+          ]),
+          div(`Hello world`),
+        ]),
+      );
+
+      return { dom };
+    }
+
+    const { sources, dispose } = run<DomSources, DomSinks>(main, {
+      dom: makeDomDriver(createInitialRenderTarget()),
+    });
+
+    sources.dom.elements().skip(1).take(1)
+      .observe(elements => {
+        const rootElement = elements[0] as HTMLDivElement;
+
+        assert.strictEqual(rootElement.id, 'test');
+        assert.strictEqual(rootElement.childNodes.length, 1);
+
+        const page = rootElement.childNodes[0] as HTMLDivElement;
+
+        assert.strictEqual(page.childNodes.length, 3);
+
+        assert.strictEqual((page.childNodes[0] as HTMLHeadingElement).tagName, 'H2');
+        assert.strictEqual((page.childNodes[1] as HTMLDivElement).tagName, 'DIV');
+
+        dispose();
+        done();
+      })
+      .catch(done);
+  });
+});
+
+function createInitialRenderTarget(): HTMLDivElement {
+  const rootElement = document.createElement('div');
+  rootElement.id = 'test';
+  rootElement.className = 'unresolved';
+
+  const textContainer = document.createElement('div');
+
+  const firstTextNode = document.createTextNode('Motorcycle');
+
+  textContainer.appendChild(firstTextNode);
+
+  const spanElement = document.createElement('span');
+
+  const secondTextNode = document.createTextNode('.js');
+
+  spanElement.appendChild(secondTextNode);
+
+  textContainer.appendChild(spanElement);
+  textContainer.appendChild(spanElement);
+
+  rootElement.appendChild(textContainer);
+
+  document.body.appendChild(rootElement);
+
+  return rootElement;
+}

--- a/test/virtual-dom/core.ts
+++ b/test/virtual-dom/core.ts
@@ -145,7 +145,7 @@ describe('snabbdom', function () {
       }
     });
   });
-  describe('pathing an element', function () {
+  describe('patching an element', function () {
     it('changes the elements classes', function () {
       let vnode1 = h('i', { class: { i: true, am: true, horse: true } });
       let vnode2 = h('i', { class: { i: true, am: true, horse: false } });


### PR DESCRIPTION
<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [x] I added new tests for the issue I fixed or the feature I built
- [x] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`

When changing the structure of VNodes from having `.sel` to `.tagName`
`.className` and `.id` elements are much more likely to be reused.
Under this assumption Text Nodes that live under the root element
initially passed to makeDomDriver were not being patched or removed
because the API HTMLElement.children does not return Text Nodes.
The function `emptyNodeAt` also previously did not handle textContent
of nodes because of the misuse of `.children`. Using `.childNodes` fixes
this problem and required `api.tagName` to be updated to handle Text Nodes.