### PR TITLE
test(render): remove accidental `describe.only` left behind

### DIFF
--- a/test/driver/integration/rendering.ts
+++ b/test/driver/integration/rendering.ts
@@ -11,7 +11,7 @@ interface DomSinks {
   dom: Stream<VNode>;
 }
 
-describe.only('rendering', () => {
+describe('rendering', () => {
   it('patches text nodes initially present on rootElement', (done) => {
     function main() {
       const dom = just(


### PR DESCRIPTION
<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [ ] I added new tests for the issue I fixed or the feature I built
- [ ] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`

<!--
Please Continue to describe your fix / change citing an issue if possible.

If there are BREAKING CHANGES, please use one of the following to 
communicate the changes that have occured.


This change absolutely will affect users:
![yes](https://img.shields.io/badge/will%20it%20affect%20me%3F-yes-red.svg)

High probability of affecting users:
![probably will](https://img.shields.io/badge/will%20it%20affect%20me%3F-probably%20will-orange.svg)

Will affect more users than not:
![maybe will](https://img.shields.io/badge/will%20it%20affect%20me%3F-maybe%20will-yellow.svg)

Will *not* affect more users than not:
![maybe won't](https://img.shields.io/badge/will%20it%20affect%20me%3F-maybe%20won't-yellowgreen.svg)

Will only affect a few people
![probably won't](https://img.shields.io/badge/will%20it%20affect%20me%3F-probably%20won't-green.svg)

Though breaking, it will almost definitely *not* affect users:
![no](https://img.shields.io/badge/will%20it%20affect%20me%3F-no-brightgreen.svg)
-->

