### PR TITLE
fix(MotorcycleDomSource): fix for no selector in elements()

### DIFF
--- a/src/dom-driver/DomSources/MotorcycleDomSource.ts
+++ b/src/dom-driver/DomSources/MotorcycleDomSource.ts
@@ -149,11 +149,15 @@ function findMostSpecificElement(scope: string) {
 
 function findMatchingElements(selector: string, checkIsInScope: (element: HTMLElement) => boolean) {
   return function (element: HTMLElement): Array<HTMLElement> {
-    const matchedNodes = element.querySelectorAll(selector);
-    const matchedNodesArray = copy(matchedNodes as any as Array<any>);
+    const matchedNodesArray: HTMLElement[] = [];
 
-    if (element.matches(selector))
+    if (!selector || element.matches(selector))
       matchedNodesArray.push(element);
+
+    if (!selector) return matchedNodesArray;
+
+    const matchedNodes = element.querySelectorAll(selector);
+    matchedNodesArray.concat(copy(matchedNodes as any as Array<any>));
 
     return matchedNodesArray.filter(checkIsInScope);
   };


### PR DESCRIPTION
If calling elements() on a DomSource with no previous `select()` call you will receive errors about calling `querySelectorAll()` with `undefined`